### PR TITLE
Часткове прибирання обмежень з іграшок

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -19,9 +19,9 @@
   - type: EmitSoundOnTrigger
     sound: *BasePlushieSound
   - type: UseDelay
-    delay: 3.0
+    delay: 1.0 # 3.0 в оригіналі. Зміна білду Січі, #NoMorePlushie's1984
   - type: MeleeWeapon
-    attackRate: 0.333
+#    attackRate: 0.333 - прибрано білдом Січі. #NoMorePlushie's1984
     wideAnimationRotation: 180
     soundHit: *BasePlushieSound
     damage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Про ПР
<!-- Які зміни вносить цей PR? -->
Частковий реверт змін до плюшів (https://github.com/space-wizards/space-station-14/pull/39250), які збільшили затримку між їх використанням як об'єктів/зброї в 3 рази.

## Чому (ні?)
<!-- Опишіть, як це вплине на баланс гри, або поясніть, чому це було змінено. Додайте посилання на будь-які відповідні обговорення чи проблеми. -->
`FUCKING LOUD AND ANNOYING` - з оригінального ПР, думаю не так актуально для нас

## Технічні деталі
<!-- Зведений огляд змін коду для легшого перегляду. -->
yml-ки

## Медіа
<!-- Додайте медіафайли, якщо особистий представник вносить зміни в грі (одяг, предмети, функції тощо).
Невеликі виправлення/рефакторинг звільняються. Медіафайли можна використовувати у звітах про хід гри SS14 із зазначенням авторства. -->

https://github.com/user-attachments/assets/a7cfd58b-b41a-4351-91de-1bde084a4ecf

## Завдання
<!-- Підтвердіть наступне, поставивши X у дужках [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- Ви повинні розуміти, що недотримання вищезазначених інструкцій може призвести до закриття вашого запиту на розсуд розробника. -->

**Список змін**
<!-- Додайте запис у журналі змін, щоб повідомити гравців про нові функції або зміни, які можуть вплинути на ігровий процес.
Обов'язково прочитайте інструкції та видаліть цей шаблон журналу змін з блоку коментарів, щоб він відображався.
Журнал змін повинен мати запис ":cl: Sich", щоб бот розпізнав зміни та додав їх до журналу змін гри. -->
<!--
:cl: Sich
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Sich
- tweak: Повернуто стару затримку атака/використання плюшів (3->1 секунд)